### PR TITLE
Updating doc to use getText() instead of private text property

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ function App() {
         width={500}
         height={500}
         onUpdate={(err, result) => {
-          if (result) setData(result.text)
+          if (result) setData(result.getText())
           else setData('Not Found')
         }}
       />


### PR DESCRIPTION
You declare text as private and we can't use on onUpdate callback. 

To get the text you created getText() method. 